### PR TITLE
Fix: Use std::in_place for Folly compatibility

### DIFF
--- a/src/cached_policy.cpp
+++ b/src/cached_policy.cpp
@@ -49,7 +49,7 @@ bool folly::HeterogeneousAccessEqualTo<CacheEntry>::operator()(CacheEntry const&
 CachedPolicy::CachedPolicy(EvaluationFunction evaluate, std::size_t capacity, unsigned shards)
     : m_cache{std::make_shared<EvaluationCache>(std::move(evaluate))} {
     for (unsigned i = 0; i < shards; ++i) {
-        m_cache->lrus.emplace_back(folly::in_place_t(), capacity / shards);
+        m_cache->lrus.emplace_back(std::in_place, capacity / shards);
     }
 }
 


### PR DESCRIPTION
Folly has removed or deprecated folly::in_place_t. This commit updates the code to use the standard std::in_place, which resolves compilation errors with recent Folly versions.